### PR TITLE
c2service: FixUP! missing module

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,3 +1,9 @@
+soong_namespace {
+    imports: [
+        "hardware/samsung_slsi-linaro_13-e850-96/graphics"
+    ],
+}
+
 soong_config_module_type {
     name: "libexynos_headers_c2_cc_defaults",
     module_type: "cc_defaults",

--- a/Android.mk
+++ b/Android.mk
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ifeq ($(TARGET_SLSI_VARIANT),linaro)
+ifeq ($(TARGET_SLSI_VARIANT),linaro_13-e850-96)
 ifneq ($(filter exynos, $(TARGET_SOC_NAME)),)
 common_exynos_dirs := \
 	libdisplaycolor \

--- a/c2service/Android.bp
+++ b/c2service/Android.bp
@@ -30,6 +30,9 @@
 // vendor.cpp also needs to be updated because it needs the absolute path to the
 // seccomp policy file on the device.
 soong_namespace {
+    imports: [
+        "hardware/samsung_slsi-linaro_13-e850-96/graphics"
+    ],
 }
 
 package {

--- a/gralloc/Android.mk
+++ b/gralloc/Android.mk
@@ -40,8 +40,8 @@ MALI_AFBC_GRALLOC := 1
 
 LOCAL_C_INCLUDES := \
 	$(LOCAL_PATH)/../include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos5/include
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos5/include
 
 LOCAL_SRC_FILES := 	\
 	format_chooser.cpp \
@@ -78,8 +78,8 @@ LOCAL_SHARED_LIBRARIES := liblog libcutils libion_exynos libutils android.hardwa
 
 LOCAL_C_INCLUDES := \
 	$(LOCAL_PATH)/../include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos5/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos5/include \
 	$(TOP)/system/core/libsync/include
 
 LOCAL_SRC_FILES := 	\

--- a/gralloc1/Android.mk
+++ b/gralloc1/Android.mk
@@ -26,8 +26,8 @@ LOCAL_HEADER_LIBRARIES := libhardware_headers
 
 LOCAL_C_INCLUDES := \
 	$(LOCAL_PATH)/../include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos5/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos5/include \
 	$(TOP)/system/core/libsync/include
 
 LOCAL_SRC_FILES := 	\
@@ -81,8 +81,8 @@ LOCAL_SHARED_LIBRARIES := liblog libcutils libion_exynos libutils android.hardwa
 
 LOCAL_C_INCLUDES := \
 	$(LOCAL_PATH)/../include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos5/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos5/include \
 	$(TOP)/system/core/libsync/include
 
 LOCAL_SRC_FILES := 	\

--- a/gralloc3/Android.mk
+++ b/gralloc3/Android.mk
@@ -66,7 +66,7 @@ LOCAL_SHARED_LIBRARIES := liblog libcutils libutils android.hardware.graphics.al
 	libsync libhardware libhidlbase libhidltransport
 
 LOCAL_C_INCLUDES := \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/include
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include
 
 LOCAL_SRC_FILES := 	\
 	GrallocWrapper.cpp

--- a/gralloc3/src/Android.mk
+++ b/gralloc3/src/Android.mk
@@ -156,7 +156,7 @@ endif
 endif
 
 LOCAL_C_INCLUDES := $(MALI_LOCAL_PATH) $(MALI_DDK_INCLUDES) \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/include
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include
 
 # General compilation flags
 LOCAL_CFLAGS := -Werror -DLOG_TAG=\"gralloc\" -DPLATFORM_SDK_VERSION=$(PLATFORM_SDK_VERSION)
@@ -470,7 +470,7 @@ endif
 endif
 
 LOCAL_C_INCLUDES := $(MALI_LOCAL_PATH) $(MALI_DDK_INCLUDES) \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/include
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include
 
 # General compilation flags
 LOCAL_CFLAGS := -Werror -DLOG_TAG=\"gralloc\" -DPLATFORM_SDK_VERSION=$(PLATFORM_SDK_VERSION)

--- a/gralloc4/interfaces/libs/drmutils/Android.bp
+++ b/gralloc4/interfaces/libs/drmutils/Android.bp
@@ -35,7 +35,7 @@ cc_library_static {
     ],
     include_dirs: [
         ".",
-        "hardware/samsung_slsi-linaro/exynos/include",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/include",
     ],
     export_include_dirs: [
         ".",

--- a/gralloc4/src/4.x/Android.bp
+++ b/gralloc4/src/4.x/Android.bp
@@ -83,7 +83,7 @@ cc_library_shared {
         ":libgralloc_hidl_common_shared_metadata",
     ],
     include_dirs: [
-        "hardware/samsung_slsi-linaro/exynos/include",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/include",
     ],
 }
 
@@ -107,6 +107,6 @@ cc_library_shared {
         ":libgralloc_hidl_common_shared_metadata",
     ],
     include_dirs: [
-        "hardware/samsung_slsi-linaro/exynos/include",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/include",
     ],
 }

--- a/gralloc4/src/core/Android.bp
+++ b/gralloc4/src/core/Android.bp
@@ -115,7 +115,7 @@ arm_gralloc_core_cc_defaults {
         "ip_info/video_format_manager.cpp",
     ],
     include_dirs: [
-        "hardware/samsung_slsi-linaro/exynos/include",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/include",
     ],
     static_libs: [
         "libarect",

--- a/gralloc4/src/core/ip_info/hidl_defines.h
+++ b/gralloc4/src/core/ip_info/hidl_defines.h
@@ -50,7 +50,7 @@ enum class PixelFormat : int32_t {
 
         /// PrivateFormat
         /// Invariant: PrivateFormat should be non-overlapping with to PixelFormat
-        /// From exynos definition hardware/samsung_slsi-linaro/exynos/include/exynos_format.h
+        /// From exynos definition hardware/samsung_slsi-linaro_13-e850-96/exynos/include/exynos_format.h
         PRIVATE_YCBCR_420_P_M               = 0x101,
         PRIVATE_YCBCR_420_SP_M              = 0x105,
         PRIVATE_YCBCR_420_SP_M_TILED        = 0x107,

--- a/libaudio/audiohal/Android.mk
+++ b/libaudio/audiohal/Android.mk
@@ -29,8 +29,8 @@ LOCAL_SRC_FILES += \
     voice_manager_sit.c
 
 LOCAL_C_INCLUDES += \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/libaudio/audioril-sit \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/libaudio/audioril-sit/include
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libaudio/audioril-sit \
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libaudio/audioril-sit/include
 
 LOCAL_CFLAGS += -DUSE_SITRIL
 else
@@ -38,12 +38,12 @@ LOCAL_SRC_FILES += \
     voice_manager_sec.c
 
 LOCAL_C_INCLUDES += \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/libaudio/audioril-sec \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/libaudio/audioril-sec/include
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libaudio/audioril-sec \
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libaudio/audioril-sec/include
 endif
 
 LOCAL_C_INCLUDES += \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/include/libaudio/audiohal
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include/libaudio/audiohal
 
 LOCAL_HEADER_LIBRARIES := libhardware_headers
 LOCAL_SHARED_LIBRARIES := liblog libcutils libprocessgroup libaudioproxy

--- a/libaudio/audiohal_comv1/common_audiohal/Android.mk
+++ b/libaudio/audiohal_comv1/common_audiohal/Android.mk
@@ -24,7 +24,7 @@ LOCAL_SRC_FILES := \
 	audio_hw.c \
 
 LOCAL_C_INCLUDES += \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/include/libaudio/audiohal_comv1 \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include/libaudio/audiohal_comv1 \
 	$(call include-path-for, audio-utils)
 
 LOCAL_HEADER_LIBRARIES := libhardware_headers

--- a/libaudio/audioril-sec/Android.mk
+++ b/libaudio/audioril-sec/Android.mk
@@ -25,7 +25,7 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := secril_interface.c
 
 LOCAL_C_INCLUDES += \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/include/libaudio/audiohal
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include/libaudio/audiohal
 
 LOCAL_C_INCLUDES += ./include
 

--- a/libcamera3/common_v2/PlugIn/Android.mk
+++ b/libcamera3/common_v2/PlugIn/Android.mk
@@ -9,10 +9,10 @@ LOCAL_SHARED_LIBRARIES := libutils libcutils liblog
 LOCAL_MODULE := libexynoscamera_plugin
 
 LOCAL_C_INCLUDES += \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2 \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/include \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/include \
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2 \
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/include \
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn \
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/include \
     $(TOP)/bionic \
     $(TOP)/frameworks/native/libs/binder/include
 
@@ -20,7 +20,7 @@ LOCAL_CFLAGS := -Wno-unused-parameter
 LOCAL_CFLAGS += -Wno-error=date-time
 LOCAL_CFLAGS += -Wno-overloaded-virtual
 
-include $(TOP)/hardware/samsung_slsi-linaro/exynos/BoardConfigCFlags.mk
+include $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/BoardConfigCFlags.mk
 include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)
@@ -31,10 +31,10 @@ LOCAL_SHARED_LIBRARIES := libutils libcutils liblog libion
 LOCAL_MODULE := libexynoscamera_plugin_utils
 
 LOCAL_C_INCLUDES += \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2 \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/include \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/include \
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2 \
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/include \
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn \
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/include \
     $(TOP)/system/core/libion/include \
     $(TOP)/bionic \
     $(TOP)/frameworks/native/libs/binder/include
@@ -43,7 +43,7 @@ LOCAL_CFLAGS := -Wno-unused-parameter
 LOCAL_CFLAGS += -Wno-error=date-time
 LOCAL_CFLAGS += -Wno-overloaded-virtual
 
-include $(TOP)/hardware/samsung_slsi-linaro/exynos/BoardConfigCFlags.mk
+include $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/BoardConfigCFlags.mk
 include $(BUILD_SHARED_LIBRARY)
 
 # external plugins

--- a/libcamera3/common_v2/PlugIn/converter/libs/Android.mk
+++ b/libcamera3/common_v2/PlugIn/converter/libs/Android.mk
@@ -3,7 +3,7 @@
 ifeq ($(BOARD_CAMERA_USES_DUAL_CAMERA_SOLUTION_FAKE), true)
 LOCAL_CFLAGS += -DUSES_DUAL_CAMERA_SOLUTION_FAKE
 LOCAL_C_INCLUDES += \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/converter/libs/libFakeFusion
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/converter/libs/libFakeFusion
 LOCAL_SRC_FILES += \
 	../../exynos/libcamera3/common_v2/PlugIn/converter/libs/libFakeFusion/ExynosCameraPlugInConverterFakeFusion.cpp
 endif
@@ -11,7 +11,7 @@ endif
 ifeq ($(BOARD_CAMERA_USES_DUAL_CAMERA_SOLUTION_ARCSOFT), true)
 LOCAL_CFLAGS += -DUSES_DUAL_CAMERA_SOLUTION_ARCSOFT
 LOCAL_C_INCLUDES += \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera/common_v3/PlugIn/converter/libs/libArcsoftFusion
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera/common_v3/PlugIn/converter/libs/libArcsoftFusion
 LOCAL_SRC_FILES += \
 	../../exynos/libcamera3/common_v2/PlugIn/converter/libs/libArcsoftFusion/ExynosCameraPlugInConverterArcsoftFusion.cpp \
 	../../exynos/libcamera3/common_v2/PlugIn/converter/libs/libArcsoftFusion/ExynosCameraPlugInConverterArcsoftFusionBokehCapture.cpp \
@@ -23,7 +23,7 @@ endif
 ifeq ($(BOARD_CAMERA_USES_LLS_SOLUTION), true)
 LOCAL_CFLAGS += -DUSES_LLS_SOLUTION
 LOCAL_C_INCLUDES += \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/converter/libs/libLLS
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/converter/libs/libLLS
 LOCAL_SRC_FILES += \
 	../../exynos/libcamera3/common_v2/PlugIn/converter/libs/libLLS/ExynosCameraPlugInConverterLowLightShot.cpp
 endif
@@ -31,7 +31,7 @@ endif
 ifeq ($(BOARD_CAMERA_USES_CAMERA_SOLUTION_VDIS), true)
 LOCAL_CFLAGS += -DUSES_CAMERA_SOLUTION_VDIS
 LOCAL_C_INCLUDES += \
-    $(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/converter/libs/libVDIS
+    $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/converter/libs/libVDIS
 LOCAL_SRC_FILES += \
 	../../exynos/libcamera3/common_v2/PlugIn/converter/libs/libVDIS/ExynosCameraPlugInConverterVDIS.cpp
 endif

--- a/libcamera3/common_v2/PlugIn/libs/libFakeFusion/Android.mk
+++ b/libcamera3/common_v2/PlugIn/libs/libFakeFusion/Android.mk
@@ -36,12 +36,12 @@ LOCAL_SHARED_LIBRARIES := libutils libcutils liblog libexynoscamera_plugin libex
 LOCAL_MODULE := libexynoscamera_fakefusion_plugin
 
 LOCAL_C_INCLUDES += \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/ \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/ \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/libs/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/libs/libFakeFusion/include
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/ \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/ \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/libs/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/libs/libFakeFusion/include
 
 LOCAL_CFLAGS := -Wno-unused-parameter
 LOCAL_CFLAGS += -Wno-error=date-time

--- a/libcamera3/common_v2/PlugIn/libs/libFakeFusion/src/Android.mk
+++ b/libcamera3/common_v2/PlugIn/libs/libFakeFusion/src/Android.mk
@@ -9,8 +9,8 @@ LOCAL_SHARED_LIBRARIES := libutils libcutils liblog libexynosutils
 LOCAL_MODULE := libexynoscamera_fakefusion
 
 LOCAL_C_INCLUDES += \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/include \
 	$(LOCAL_PATH)/../include \
 
 LOCAL_CFLAGS := -Wno-unused-parameter

--- a/libcamera3/common_v2/PlugIn/libs/libLLS/Android.mk
+++ b/libcamera3/common_v2/PlugIn/libs/libLLS/Android.mk
@@ -14,7 +14,7 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_PRELINK_MODULE := true
 LOCAL_PREBUILT_LIBS := lib32/liblowlightshot.so
 
-include $(TOP)/hardware/samsung_slsi-linaro/exynos/BoardConfigCFlags.mk
+include $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/BoardConfigCFlags.mk
 include $(BUILD_MULTI_PREBUILT)
 
 else
@@ -29,7 +29,7 @@ LOCAL_SRC_FILES_$(TARGET_ARCH) := lib64/$(LOCAL_MODULE)$(LOCAL_MODULE_SUFFIX)
 LOCAL_SRC_FILES_$(TARGET_2ND_ARCH) := lib32/$(LOCAL_MODULE)$(LOCAL_MODULE_SUFFIX)
 LOCAL_MULTILIB := both
 
-include $(TOP)/hardware/samsung_slsi-linaro/exynos/BoardConfigCFlags.mk
+include $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/BoardConfigCFlags.mk
 include $(BUILD_PREBUILT)
 endif
 
@@ -43,17 +43,17 @@ LOCAL_MODULE := libexynoscamera_lowlightshot_plugin
 
 LOCAL_C_INCLUDES += \
 	$(TOP)/system/core/libcutils/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/ \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/ \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/libs/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/libs/libLLS/include
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/ \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/ \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/libs/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/libs/libLLS/include
 
 LOCAL_CFLAGS := -Wno-unused-parameter
 LOCAL_CFLAGS += -Wno-error=date-time
 
-include $(TOP)/hardware/samsung_slsi-linaro/exynos/BoardConfigCFlags.mk
+include $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/BoardConfigCFlags.mk
 include $(BUILD_SHARED_LIBRARY)
 
 # build sources to make builtin lowlightshow lib

--- a/libcamera3/common_v2/PlugIn/libs/libLLS/src/Android.mk
+++ b/libcamera3/common_v2/PlugIn/libs/libLLS/src/Android.mk
@@ -10,14 +10,14 @@ LOCAL_SHARED_LIBRARIES := libutils libcutils liblog libexynosutils libexynoscame
 LOCAL_MODULE := liblowlightshot
 
 LOCAL_C_INCLUDES += \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/9810 \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common/PlugIn/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/9810 \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common/PlugIn/include \
 	$(LOCAL_PATH)/../include \
 
 LOCAL_CFLAGS := -Wno-unused-parameter
 LOCAL_CFLAGS += -Wno-error=date-time
 
-include $(TOP)/hardware/samsung_slsi-linaro/exynos/BoardConfigCFlags.mk
+include $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/BoardConfigCFlags.mk
 include $(BUILD_SHARED_LIBRARY)
 endif

--- a/libcamera3/common_v2/PlugIn/libs/libVDIS/Android.mk
+++ b/libcamera3/common_v2/PlugIn/libs/libVDIS/Android.mk
@@ -14,7 +14,7 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_PRELINK_MODULE := true
 LOCAL_PREBUILT_LIBS := lib32/libvdis.so
 
-include $(TOP)/hardware/samsung_slsi-linaro/exynos/BoardConfigCFlags.mk
+include $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/BoardConfigCFlags.mk
 include $(BUILD_MULTI_PREBUILT)
 
 else
@@ -29,7 +29,7 @@ LOCAL_SRC_FILES_$(TARGET_ARCH) := lib64/$(LOCAL_MODULE)$(LOCAL_MODULE_SUFFIX)
 LOCAL_SRC_FILES_$(TARGET_2ND_ARCH) := lib32/$(LOCAL_MODULE)$(LOCAL_MODULE_SUFFIX)
 LOCAL_MULTILIB := both
 
-include $(TOP)/hardware/samsung_slsi-linaro/exynos/BoardConfigCFlags.mk
+include $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/BoardConfigCFlags.mk
 include $(BUILD_PREBUILT)
 endif
 
@@ -43,17 +43,17 @@ LOCAL_MODULE := libexynoscamera_vdis_plugin
 
 LOCAL_C_INCLUDES += \
 	$(TOP)/system/core/libcutils/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/ \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/ \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/libs/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/libs/libVDIS/include
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/ \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/ \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/libs/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/libs/libVDIS/include
 
 LOCAL_CFLAGS := -Wno-unused-parameter
 LOCAL_CFLAGS += -Wno-error=date-time
 
-include $(TOP)/hardware/samsung_slsi-linaro/exynos/BoardConfigCFlags.mk
+include $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/BoardConfigCFlags.mk
 include $(BUILD_SHARED_LIBRARY)
 
 # build sources to make builtin vdis lib

--- a/libcamera3/common_v2/PlugIn/libs/libVDIS/src/Android.mk
+++ b/libcamera3/common_v2/PlugIn/libs/libVDIS/src/Android.mk
@@ -9,13 +9,13 @@ LOCAL_SHARED_LIBRARIES := libutils libcutils liblog libexynosutils libexynoscame
 LOCAL_MODULE := libvdis
 
 LOCAL_C_INCLUDES += \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/9xxx \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera3/common_v2/PlugIn/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/9xxx \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera3/common_v2/PlugIn/include \
 	$(LOCAL_PATH)/../include \
 
 LOCAL_CFLAGS := -Wno-unused-parameter
 LOCAL_CFLAGS += -Wno-error=date-time
 
-include $(TOP)/hardware/samsung_slsi-linaro/exynos/BoardConfigCFlags.mk
+include $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/BoardConfigCFlags.mk
 include $(BUILD_SHARED_LIBRARY)

--- a/libcamera_external/Android.mk
+++ b/libcamera_external/Android.mk
@@ -21,12 +21,12 @@ LOCAL_PROPRIETARY_MODULE := true
 
 LOCAL_C_INCLUDES += \
 	$(LOCAL_PATH)/../include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libcamera_external \
-	$(TOP)/hardware/samsung_slsi-linaro/$(TARGET_BOARD_PLATFORM)/include \
-	$(TOP)/hardware/samsung_slsi-linaro/$(TARGET_SOC)/include \
-	$(TOP)/hardware/samsung_slsi-linaro/$(TARGET_SOC)/libcamera \
-	$(TOP)/hardware/samsung_slsi-linaro/$(TARGET_SOC)/libcamera_external \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libcamera_external \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/$(TARGET_BOARD_PLATFORM)/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/$(TARGET_SOC)/include \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/$(TARGET_SOC)/libcamera \
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/$(TARGET_SOC)/libcamera_external \
 	frameworks/native/include \
 	system/media/camera/include
 

--- a/libcsc/Android.mk
+++ b/libcsc/Android.mk
@@ -10,7 +10,7 @@ LOCAL_SRC_FILES := \
 	csc.c
 
 LOCAL_C_INCLUDES := \
-	hardware/samsung_slsi-linaro/$(TARGET_BOARD_PLATFORM)/include \
+	hardware/samsung_slsi-linaro_13-e850-96/$(TARGET_BOARD_PLATFORM)/include \
 	$(LOCAL_PATH)/../include \
 	$(LOCAL_PATH)/../libexynosutils
 
@@ -41,5 +41,5 @@ endif
 
 LOCAL_CFLAGS += -Wno-unused-variable -Wno-unused-label
 
-include $(TOP)/hardware/samsung_slsi-linaro/exynos/BoardConfigCFlags.mk
+include $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/BoardConfigCFlags.mk
 include $(BUILD_SHARED_LIBRARY)

--- a/libexynosgraphicbuffer/Android.bp
+++ b/libexynosgraphicbuffer/Android.bp
@@ -63,8 +63,8 @@ exynosgraphicbuffercore_cc_defaults {
         gralloc_version: {
             three: {
                 include_dirs: [
-                    "hardware/samsung_slsi-linaro/exynos/include",
-                    "hardware/samsung_slsi-linaro/exynos/gralloc3/src",
+                    "hardware/samsung_slsi-linaro_13-e850-96/exynos/include",
+                    "hardware/samsung_slsi-linaro_13-e850-96/exynos/gralloc3/src",
                 ],
 
                 srcs: [
@@ -73,8 +73,8 @@ exynosgraphicbuffercore_cc_defaults {
             },
             four: {
                 include_dirs: [
-                    "hardware/samsung_slsi-linaro/exynos/include",
-                    "hardware/samsung_slsi-linaro/exynos/gralloc4/src",
+                    "hardware/samsung_slsi-linaro_13-e850-96/exynos/include",
+                    "hardware/samsung_slsi-linaro_13-e850-96/exynos/gralloc4/src",
                                 ],
 
                                 srcs: [
@@ -83,8 +83,8 @@ exynosgraphicbuffercore_cc_defaults {
             },
             four_sgr: {
                 include_dirs: [
-                    "hardware/samsung_slsi-linaro/exynos/include",
-                    "hardware/samsung_slsi-linaro/sgpu/sgpu_gralloc/src/interface",
+                    "hardware/samsung_slsi-linaro_13-e850-96/exynos/include",
+                    "hardware/samsung_slsi-linaro_13-e850-96/sgpu/sgpu_gralloc/src/interface",
                 ],
 
                 srcs: [

--- a/libexynosgraphicbuffer/gralloc3/README.txt
+++ b/libexynosgraphicbuffer/gralloc3/README.txt
@@ -9,11 +9,11 @@ To use libexynosgraphicbuffer add it as a shared library to your module and
 #include <ExynosGraphicBuffer.h>
 
 Location of header:
-/hardware/samsung_slsi-linaro/exynos/include
+/hardware/samsung_slsi-linaro_13-e850-96/exynos/include
 
 Location of source code:
-/hardware/samsung_slsi-linaro/exynos/gralloc3/libexynosgraphicbuffer
-/hardware/samsung_slsi-linaro/exynos/gralloc4/libexynosgraphicbuffer (will be added with gralloc4)
+/hardware/samsung_slsi-linaro_13-e850-96/exynos/gralloc3/libexynosgraphicbuffer
+/hardware/samsung_slsi-linaro_13-e850-96/exynos/gralloc4/libexynosgraphicbuffer (will be added with gralloc4)
 
 
 

--- a/libexynosgraphicbuffer/gralloc3/drmutils/Android.bp
+++ b/libexynosgraphicbuffer/gralloc3/drmutils/Android.bp
@@ -35,7 +35,7 @@ cc_library_static {
     ],
     include_dirs: [
         ".",
-        "hardware/samsung_slsi-linaro/exynos/include",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/include",
     ],
     export_include_dirs: [
         ".",

--- a/libexynosgraphicbuffer/gralloc4/README.txt
+++ b/libexynosgraphicbuffer/gralloc4/README.txt
@@ -9,11 +9,11 @@ To use libexynosgraphicbuffer add it as a shared library to your module and
 #include <ExynosGraphicBuffer.h>
 
 Location of header:
-/hardware/samsung_slsi-linaro/exynos/include
+/hardware/samsung_slsi-linaro_13-e850-96/exynos/include
 
 Location of source code:
-/hardware/samsung_slsi-linaro/exynos/gralloc3/libexynosgraphicbuffer
-/hardware/samsung_slsi-linaro/exynos/gralloc4/libexynosgraphicbuffer (will be added with gralloc4)
+/hardware/samsung_slsi-linaro_13-e850-96/exynos/gralloc3/libexynosgraphicbuffer
+/hardware/samsung_slsi-linaro_13-e850-96/exynos/gralloc4/libexynosgraphicbuffer (will be added with gralloc4)
 
 
 

--- a/libexynosutils/Android.mk
+++ b/libexynosutils/Android.mk
@@ -36,5 +36,5 @@ LOCAL_SRC_FILES += exynos_format_v4l2.c
 LOCAL_C_INCLUDES += \
 	$(LOCAL_PATH)/../include
 
-include $(TOP)/hardware/samsung_slsi-linaro/exynos/BoardConfigCFlags.mk
+include $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/BoardConfigCFlags.mk
 include $(BUILD_SHARED_LIBRARY)

--- a/libsbwchelper/Android.bp
+++ b/libsbwchelper/Android.bp
@@ -21,7 +21,7 @@ cc_library_shared {
     proprietary: true,
 
     include_dirs: [
-        "hardware/samsung_slsi-linaro/exynos/include",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/include",
     ],
 
     static_libs: [

--- a/libsbwchelper/tests/Android.bp
+++ b/libsbwchelper/tests/Android.bp
@@ -25,7 +25,7 @@ cc_test {
     ],
 
     include_dirs: [
-        "hardware/samsung_slsi-linaro/exynos/include",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/include",
     ],
 
     static_libs:[

--- a/libswconverter/Android.mk
+++ b/libswconverter/Android.mk
@@ -36,7 +36,7 @@ endif
 
 LOCAL_C_INCLUDES := \
 	$(LOCAL_PATH)/../include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/include
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/include
 
 LOCAL_MODULE := libswconverter
 

--- a/libv4l2/Android.mk
+++ b/libv4l2/Android.mk
@@ -22,7 +22,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES := \
 	$(LOCAL_PATH)/../include \
-	$(TOP)/hardware/samsung_slsi-linaro/exynos/libexynosutils
+	$(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/libexynosutils
 
 LOCAL_SHARED_LIBRARIES := \
 	liblog \
@@ -35,5 +35,5 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_PROPRIETARY_MODULE := true
 LOCAL_CFLAGS += -Wno-unused-parameter -Wno-unused-function
 
-include $(TOP)/hardware/samsung_slsi-linaro/exynos/BoardConfigCFlags.mk
+include $(TOP)/hardware/samsung_slsi-linaro_13-e850-96/exynos/BoardConfigCFlags.mk
 include $(BUILD_SHARED_LIBRARY)

--- a/tee/TlcKeymint/Android.bp
+++ b/tee/TlcKeymint/Android.bp
@@ -29,9 +29,9 @@
 // See: http://go/android-license-faq
 soong_namespace {
     imports: [
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi520",
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi510",
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi500"
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi520",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi510",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi500"
     ],
 }
 

--- a/tee/TlcTeeKeymaster4/Android.bp
+++ b/tee/TlcTeeKeymaster4/Android.bp
@@ -15,9 +15,9 @@
 //
 soong_namespace {
     imports: [
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi520",
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi510",
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi500"
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi520",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi510",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi500"
     ],
 }
 

--- a/tee/kinibi500/system/TeeService/Android.bp
+++ b/tee/kinibi500/system/TeeService/Android.bp
@@ -49,8 +49,8 @@ cc_library_static {
     ],
 
     include_dirs: [
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi500/vendor/ClientLib/include",
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi500/vendor/ClientLib/include/GP",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi500/vendor/ClientLib/include",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi500/vendor/ClientLib/include/GP",
     ],
 
 }
@@ -83,8 +83,8 @@ cc_library_shared {
     ],
 
     include_dirs: [
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi500/vendor/ClientLib/include",
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi500/vendor/ClientLib/include/GP",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi500/vendor/ClientLib/include",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi500/vendor/ClientLib/include/GP",
     ],
 
     export_include_dirs: [

--- a/tee/kinibi500/system/TeeServiceJava/Android.bp
+++ b/tee/kinibi500/system/TeeServiceJava/Android.bp
@@ -9,8 +9,8 @@ cc_library_shared {
     ],
 
     include_dirs: [
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi500/system/TeeService",
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi500/vendor/hardware/interfaces/tee/1.1/default",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi500/system/TeeService",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi500/vendor/hardware/interfaces/tee/1.1/default",
     ],
 
     // Undefine NDEBUG to enable LOG_D in log

--- a/tee/kinibi500/vendor/hardware/interfaces/Android.bp
+++ b/tee/kinibi500/vendor/hardware/interfaces/Android.bp
@@ -1,4 +1,4 @@
 hidl_package_root {
     name: "vendor.trustonic",
-    path: "hardware/samsung_slsi-linaro/exynos/tee/kinibi500/vendor/hardware/interfaces",
+    path: "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi500/vendor/hardware/interfaces",
 }

--- a/tee/kinibi500/vendor/hardware/interfaces/tee/1.1/default/Android.bp
+++ b/tee/kinibi500/vendor/hardware/interfaces/tee/1.1/default/Android.bp
@@ -20,8 +20,8 @@ cc_library_static {
     ],
 
     include_dirs: [
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi500/vendor/ClientLib/include",
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi500/vendor/ClientLib/include/GP",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi500/vendor/ClientLib/include",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi500/vendor/ClientLib/include/GP",
         "system/memory/libion/kernel-headers",
     ],
 
@@ -61,8 +61,8 @@ cc_binary {
     ],
 
     include_dirs: [
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi500/vendor/ClientLib/include",
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi500/vendor/ClientLib/include/GP",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi500/vendor/ClientLib/include",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi500/vendor/ClientLib/include/GP",
     ],
 
     cflags: [

--- a/tee/kinibi510/vendor/hardware/interfaces/Android.bp
+++ b/tee/kinibi510/vendor/hardware/interfaces/Android.bp
@@ -1,5 +1,5 @@
 hidl_package_root {
     name: "vendor.trustonic",
     /* ExySp */
-    path: "hardware/samsung_slsi-linaro/exynos/tee/kinibi510/vendor/hardware/interfaces",
+    path: "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi510/vendor/hardware/interfaces",
 }

--- a/tee/kinibi520/vendor/hardware/interfaces/Android.bp
+++ b/tee/kinibi520/vendor/hardware/interfaces/Android.bp
@@ -1,5 +1,5 @@
 hidl_package_root {
     name: "vendor.trustonic",
     /* ExySp */
-    path: "hardware/samsung_slsi-linaro/exynos/tee/kinibi520/vendor/hardware/interfaces",
+    path: "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi520/vendor/hardware/interfaces",
 }

--- a/usb/Android.bp
+++ b/usb/Android.bp
@@ -46,7 +46,7 @@ exynos_usb_gadget_hal {
 			},
 			default: {
 				include_dirs: [
-				"hardware/samsung_slsi-linaro/exynos/usb/default",
+				"hardware/samsung_slsi-linaro_13-e850-96/exynos/usb/default",
 				],
 			},
 		},

--- a/weaver/Android.bp
+++ b/weaver/Android.bp
@@ -1,8 +1,8 @@
 soong_namespace {
     imports: [
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi520",
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi510",
-        "hardware/samsung_slsi-linaro/exynos/tee/kinibi500"
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi520",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi510",
+        "hardware/samsung_slsi-linaro_13-e850-96/exynos/tee/kinibi500"
     ],
 }
 


### PR DESCRIPTION
* samsung.hardware.media.c2@1.1-default-service depends on libio_exynos and the android buildsystem cannot find the module. 
* Import the right namespace path fixed it.